### PR TITLE
Fix WebSocket Mixed Content error on HTTPS

### DIFF
--- a/auth_integration.py
+++ b/auth_integration.py
@@ -189,8 +189,9 @@ AUTH_HTML = """
             authBtn.disabled = true;
             authBtn.textContent = 'Authenticating...';
             
-            // Connect WebSocket
-            ws = new WebSocket(`ws://${window.location.host}/auth/ws`);
+            // Connect WebSocket with proper protocol selection
+            const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+            ws = new WebSocket(`${protocol}//${window.location.host}/auth/ws`);
             
             ws.onopen = () => {
                 addTerminalLine('Starting Claude authentication...');


### PR DESCRIPTION
## Summary
- Fixed WebSocket connection issue when accessing the authentication page over HTTPS
- Changed hardcoded `ws://` protocol to dynamically select `wss://` when on HTTPS

## Problem
When accessing the authentication page at `https://litellm-claude-code-production.up.railway.app/auth`, the browser blocks the WebSocket connection with a Mixed Content error because the page tries to connect to `ws://` instead of `wss://`.

## Solution
Modified line 176 in `auth_integration.py` to detect the current protocol and use the appropriate WebSocket protocol:

```javascript
// Before:
ws = new WebSocket(`ws://${window.location.host}/auth/ws`);

// After:
const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
ws = new WebSocket(`${protocol}//${window.location.host}/auth/ws`);
```

This ensures secure WebSocket connections on HTTPS deployments while maintaining compatibility with HTTP deployments.

## Test Plan
- [x] Access `/auth` page over HTTPS
- [x] Verify WebSocket connects using `wss://` protocol
- [x] Complete authentication flow successfully
- [x] Verify HTTP deployments still work with `ws://`

🤖 Generated with [Claude Code](https://claude.ai/code)